### PR TITLE
Disable RAM32x1D synthesis

### DIFF
--- a/techlibs/xilinx/drams.txt
+++ b/techlibs/xilinx/drams.txt
@@ -1,17 +1,4 @@
 
-bram $__XILINX_RAM32X1D
-  init 1
-  abits 5
-  dbits 1
-  groups 2
-  ports  1 1
-  wrmode 0 1
-  enable 0 1
-  transp 0 0
-  clocks 0 1
-  clkpol 0 1
-endbram
-
 bram $__XILINX_RAM64X1D
   init 1
   abits 6
@@ -38,11 +25,6 @@ bram $__XILINX_RAM128X1D
   clkpol 0 1
 endbram
 
-
-match $__XILINX_RAM32X1D
-  make_outreg
-  or_next_if_better
-endmatch
 
 match $__XILINX_RAM64X1D
   make_outreg


### PR DESCRIPTION
This is because RAM32X1D is not currently working on symbiflow-arch-defs.

Once https://github.com/SymbiFlow/symbiflow-arch-defs/issues/409 is fixed, this commit can be reverted.