### PR TITLE
Use CARRY4 (with an explicit COUT) instead of CARRY0/CARRY.

### DIFF
--- a/techlibs/xilinx/arith_map.v
+++ b/techlibs/xilinx/arith_map.v
@@ -52,7 +52,6 @@ module _80_xilinx_lcu (P, G, CI, CO);
 				CARRY4 carry4_1st_part
 				(
 				.CYINIT(CI),
-				.CI    (1'd0),
 				.DI    (G [(Y_WIDTH - 1):i*4]),
 				.S     (S [(Y_WIDTH - 1):i*4]),
 				.CO    (CO[(Y_WIDTH - 1):i*4]),
@@ -61,7 +60,6 @@ module _80_xilinx_lcu (P, G, CI, CO);
 			end else begin
 				CARRY4 carry4_part
 				(
-				.CYINIT(1'd0),
 				.CI    (C [i*4 - 1]),
 				.DI    (G [(Y_WIDTH - 1):i*4]),
 				.S     (S [(Y_WIDTH - 1):i*4]),
@@ -77,7 +75,6 @@ module _80_xilinx_lcu (P, G, CI, CO);
 				CARRY4 carry4_1st_full
 				(
 				.CYINIT(CI),
-				.CI    (1'd0),
 				.DI    (G [((i+1)*4 - 1):i*4]),
 				.S     (S [((i+1)*4 - 1):i*4]),
 				.CO    (CO[((i+1)*4 - 1):i*4]),
@@ -86,7 +83,6 @@ module _80_xilinx_lcu (P, G, CI, CO);
 			end else begin
 				CARRY4 carry4_full
 				(
-				.CYINIT(1'd0),
 				.CI    (C [i*4 - 1]),
 				.DI    (G [((i+1)*4 - 1):i*4]),
 				.S     (S [((i+1)*4 - 1):i*4]),
@@ -183,7 +179,6 @@ module _80_xilinx_alu (A, B, CI, BI, X, Y, CO);
 				CARRY4 carry4_1st_part
 				(
 				.CYINIT(CI),
-				.CI    (1'd0),
 				.DI    (DI[(Y_WIDTH - 1):i*4]),
 				.S     (S [(Y_WIDTH - 1):i*4]),
 				.O     (Y [(Y_WIDTH - 1):i*4]),
@@ -193,7 +188,6 @@ module _80_xilinx_alu (A, B, CI, BI, X, Y, CO);
 			end else begin
 				CARRY4 carry4_part
 				(
-				.CYINIT(1'd0),
 				.CI    (C [i*4 - 1]),
 				.DI    (DI[(Y_WIDTH - 1):i*4]),
 				.S     (S [(Y_WIDTH - 1):i*4]),
@@ -210,7 +204,6 @@ module _80_xilinx_alu (A, B, CI, BI, X, Y, CO);
 				CARRY4 carry4_1st_full
 				(
 				.CYINIT(CI),
-				.CI    (1'd0),
 				.DI    (DI[((i+1)*4 - 1):i*4]),
 				.S     (S [((i+1)*4 - 1):i*4]),
 				.O     (Y [((i+1)*4 - 1):i*4]),
@@ -220,7 +213,6 @@ module _80_xilinx_alu (A, B, CI, BI, X, Y, CO);
 			end else begin
 				CARRY4 carry4_full
 				(
-				.CYINIT(1'd0),
 				.CI    (C [i*4 - 1]),
 				.DI    (DI[((i+1)*4 - 1):i*4]),
 				.S     (S [((i+1)*4 - 1):i*4]),
@@ -264,7 +256,6 @@ module _80_xilinx_alu (A, B, CI, BI, X, Y, CO);
 				CARRY4_COUT carry4_1st_part
 				(
 				.CYINIT(CI),
-				.CI    (1'd0),
 				.DI    (DI[(Y_WIDTH - 1):i*4]),
 				.S     (S [(Y_WIDTH - 1):i*4]),
 				.O     (Y [(Y_WIDTH - 1):i*4]),
@@ -274,7 +265,6 @@ module _80_xilinx_alu (A, B, CI, BI, X, Y, CO);
 			end else begin
 				CARRY4_COUT carry4_part
 				(
-				.CYINIT(1'd0),
 				.CI    (CO_CHAIN [i-1]),
 				.DI    (DI[(Y_WIDTH - 1):i*4]),
 				.S     (S [(Y_WIDTH - 1):i*4]),
@@ -291,7 +281,6 @@ module _80_xilinx_alu (A, B, CI, BI, X, Y, CO);
 				CARRY4_COUT carry4_1st_full
 				(
 				.CYINIT(CI),
-				.CI    (1'd0),
 				.DI    (DI[((i+1)*4 - 1):i*4]),
 				.S     (S [((i+1)*4 - 1):i*4]),
 				.O     (Y [((i+1)*4 - 1):i*4]),
@@ -302,7 +291,6 @@ module _80_xilinx_alu (A, B, CI, BI, X, Y, CO);
 			end else begin
 				CARRY4_COUT carry4_full
 				(
-				.CYINIT(1'd0),
 				.CI    (CO_CHAIN[i-1]),
 				.DI    (DI[((i+1)*4 - 1):i*4]),
 				.S     (S [((i+1)*4 - 1):i*4]),

--- a/techlibs/xilinx/arith_map.v
+++ b/techlibs/xilinx/arith_map.v
@@ -180,7 +180,7 @@ module _80_xilinx_alu (A, B, CI, BI, X, Y, CO);
 
 			// First one
 			if (i == 0) begin
-				CARRY4 #(.IS_INITIALIZED(1'd1)) carry4_1st_part
+				CARRY4 carry4_1st_part
 				(
 				.CYINIT(CI),
 				.CI    (1'd0),
@@ -207,7 +207,7 @@ module _80_xilinx_alu (A, B, CI, BI, X, Y, CO);
 
 			// First one
 			if (i == 0) begin
-				CARRY4 #(.IS_INITIALIZED(1'd1)) carry4_1st_full
+				CARRY4 carry4_1st_full
 				(
 				.CYINIT(CI),
 				.CI    (1'd0),
@@ -235,11 +235,14 @@ module _80_xilinx_alu (A, B, CI, BI, X, Y, CO);
 
 `elsif _EXPLICIT_CARRY
 
-	wire [Y_WIDTH-1:0] S = AA ^ BB;
-	wire [Y_WIDTH-1:0] DI = AA & BB;
+	localparam CARRY4_COUNT = (Y_WIDTH + 3) / 4;
+	localparam MAX_WIDTH    = CARRY4_COUNT * 4;
+	localparam PAD_WIDTH    = MAX_WIDTH - Y_WIDTH;
 
-	wire CINIT;
-	// Carry chain.
+	wire [MAX_WIDTH-1:0] S  = {{PAD_WIDTH{1'b0}}, AA ^ BB};
+	wire [MAX_WIDTH-1:0] DI = {{PAD_WIDTH{1'b0}}, AA & BB};
+
+	// Carry chain between CARRY4 blocks.
 	//
 	// VPR requires that the carry chain never hit the fabric.	The CO input
 	// to this techmap is the carry outputs for synthesis, e.g. might hit the
@@ -248,87 +251,69 @@ module _80_xilinx_alu (A, B, CI, BI, X, Y, CO);
 	// So we maintain two wire sets, CO_CHAIN is the carry that is for VPR,
 	// e.g. off fabric dedicated chain.  CO is the carry outputs that are
 	// available to the fabric.
-	wire [Y_WIDTH-1:0] CO_CHAIN;
-	wire [Y_WIDTH-1:0] C = {CO_CHAIN, CINIT};
+	wire [CARRY4_COUNT-1:0] CO_CHAIN;
 
-	// If carry chain is being initialized to a constant, techmap the constant
-	// source.	Otherwise techmap the fabric source.
-	generate for (i = 0; i < 1; i = i + 1) begin:slice
-		CARRY0 #(.CYINIT_FABRIC(1)) carry(
-			.CI_INIT(CI),
-			.DI(DI[0]),
-			.S(S[0]),
-			.CO_CHAIN(CO_CHAIN[0]),
-			.CO_FABRIC(CO[0]),
-			.O(Y[0])
-		);
-	end endgenerate
+	genvar i;
+	generate for (i = 0; i < CARRY4_COUNT; i = i + 1) begin:slice
 
-	generate for (i = 1; i < Y_WIDTH-1; i = i + 1) begin:slice
-		if(i % 4 == 0) begin
-			CARRY0 carry (
-				.CI(C[i]),
-				.DI(DI[i]),
-				.S(S[i]),
-				.CO_CHAIN(CO_CHAIN[i]),
-				.CO_FABRIC(CO[i]),
-				.O(Y[i])
-			);
-		end
-		else
-		begin
-			CARRY carry (
-				.CI(C[i]),
-				.DI(DI[i]),
-				.S(S[i]),
-				.CO_CHAIN(CO_CHAIN[i]),
-				.CO_FABRIC(CO[i]),
-				.O(Y[i])
-			);
-		end
-	end endgenerate
+		// Partially occupied CARRY4
+		if ((i+1)*4 > Y_WIDTH) begin
 
-	generate for (i = Y_WIDTH-1; i < Y_WIDTH; i = i + 1) begin:slice
-		if(i % 4 == 0) begin
-			CARRY0 top_of_carry (
-				.CI(C[i]),
-				.DI(DI[i]),
-				.S(S[i]),
-				.CO_CHAIN(CO_CHAIN[i]),
-				.O(Y[i])
-			);
+			// First one
+			if (i == 0) begin
+				CARRY4_COUT carry4_1st_part
+				(
+				.CYINIT(CI),
+				.CI    (1'd0),
+				.DI    (DI[(Y_WIDTH - 1):i*4]),
+				.S     (S [(Y_WIDTH - 1):i*4]),
+				.O     (Y [(Y_WIDTH - 1):i*4]),
+				.CO    (CO[(Y_WIDTH - 1):i*4]),
+				);
+			// Another one
+			end else begin
+				CARRY4_COUT carry4_part
+				(
+				.CYINIT(1'd0),
+				.CI    (CO_CHAIN [i-1]),
+				.DI    (DI[(Y_WIDTH - 1):i*4]),
+				.S     (S [(Y_WIDTH - 1):i*4]),
+				.O     (Y [(Y_WIDTH - 1):i*4]),
+				.CO    (CO[(Y_WIDTH - 1):i*4])
+				);
+			end
+
+		// Fully occupied CARRY4
+		end else begin
+
+			// First one
+			if (i == 0) begin
+				CARRY4_COUT carry4_1st_full
+				(
+				.CYINIT(CI),
+				.CI    (1'd0),
+				.DI    (DI[((i+1)*4 - 1):i*4]),
+				.S     (S [((i+1)*4 - 1):i*4]),
+				.O     (Y [((i+1)*4 - 1):i*4]),
+				.CO    (CO[((i+1)*4 - 1):i*4]),
+				.COUT(CO_CHAIN[i])
+				);
+			// Another one
+			end else begin
+				CARRY4_COUT carry4_full
+				(
+				.CYINIT(1'd0),
+				.CI    (CO_CHAIN[i-1]),
+				.DI    (DI[((i+1)*4 - 1):i*4]),
+				.S     (S [((i+1)*4 - 1):i*4]),
+				.O     (Y [((i+1)*4 - 1):i*4]),
+				.CO    (CO[((i+1)*4 - 1):i*4]),
+				.COUT(CO_CHAIN[i])
+				);
+			end
+
 		end
-		else
-		begin
-			CARRY top_of_carry (
-				.CI(C[i]),
-				.DI(DI[i]),
-				.S(S[i]),
-				.CO_CHAIN(CO_CHAIN[i]),
-				.O(Y[i])
-			);
-		end
-		// Turns out CO_FABRIC and O both use [ABCD]MUX, so provide
-		// a non-congested path to output the top of the carry chain.
-		// Registering the output of the CARRY block would solve this, but not
-		// all designs do that.
-		if((i+1) % 4 == 0) begin
-			CARRY0 carry_output (
-				.CI(CO_CHAIN[i]),
-				.DI(0),
-				.S(0),
-				.O(CO[i])
-			);
-		end
-		else
-		begin
-			CARRY carry_output (
-				.CI(CO_CHAIN[i]),
-				.DI(0),
-				.S(0),
-				.O(CO[i])
-			);
-		end
+
 	end endgenerate
 
 `else

--- a/techlibs/xilinx/cells_sim.v
+++ b/techlibs/xilinx/cells_sim.v
@@ -181,23 +181,14 @@ endmodule
 
 `ifdef _EXPLICIT_CARRY
 
-module CARRY0(output CO_CHAIN, CO_FABRIC, O, input CI, CI_INIT, DI, S);
-  parameter CYINIT_FABRIC = 0;
-  wire CI_COMBINE;
-  if(CYINIT_FABRIC) begin
-    assign CI_COMBINE = CI_INIT;
-  end else begin
-    assign CI_COMBINE = CI;
-  end
-  assign CO_CHAIN = S ? CI_COMBINE : DI;
-  assign CO_FABRIC = S ? CI_COMBINE : DI;
-  assign O = S ^ CI_COMBINE;
-endmodule
-
-module CARRY(output CO_CHAIN, CO_FABRIC, O, input CI, DI, S);
-  assign CO_CHAIN = S ? CI : DI;
-  assign CO_FABRIC = S ? CI : DI;
-  assign O = S ^ CI;
+module CARRY4_COUT(output [3:0] CO, O, output COUT, input CI, CYINIT, input [3:0] DI, S);
+  assign O = S ^ {CO[2:0], CI | CYINIT};
+  assign CO[0] = S[0] ? CI | CYINIT : DI[0];
+  assign CO[1] = S[1] ? CO[0] : DI[1];
+  assign CO[2] = S[2] ? CO[1] : DI[2];
+  wire CO_TOP  = S[3] ? CO[2] : DI[3];
+  assign CO[3] = CO_TOP;
+  assign COUT = CO_TOP;
 endmodule
 
 `endif


### PR DESCRIPTION
Yosys side change for fixing https://github.com/SymbiFlow/symbiflow-arch-defs/issues/729