### PR TITLE
Fixes parsing based constvals starting with '_'

### DIFF
--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -306,7 +306,7 @@ static bool isUserType(std::string &s)
 	return TOK_BASE;
 }
 
-<BASED_CONST>[0-9a-fA-FzxZX?][0-9a-fA-FzxZX?_]* {
+<BASED_CONST>[_]*[0-9a-fA-FzxZX?][0-9a-fA-FzxZX?_]* {
 	BEGIN(0);
 	yylval->string = new std::string(yytext);
 	return TOK_BASED_CONSTVAL;


### PR DESCRIPTION
Example of fixed based constval: 2'b_10;

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>