### PR TITLE
Adding variable to ABCMKARGS option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,14 @@ ABCPULL = 1
 ABCURL ?= https://github.com/YosysHQ/abc
 ABCMKARGS = CC="$(CXX)" CXX="$(CXX)" ABC_USE_LIBSTDCXX=1
 
+ifeq ($(ENABLE_ABC),1)
+ifeq ($(ENABLE_LIBYOSYS),1)
+ifeq ($(LINK_ABC),1)
+ABCMKARGS += ABC_USE_PIC=1
+endif
+endif
+endif
+
 # set ABCEXTERNAL = <abc-command> to use an external ABC instance
 # Note: The in-tree ABC (yosys-abc) will not be installed when ABCEXTERNAL is set.
 ABCEXTERNAL ?=


### PR DESCRIPTION
While generating libyosys.so with ABC, ABC needs to be compiled with -fPIC option. To enable that, we need to add 'ABC_USE_PIC=1' to ABCMKARGS variable. Is this is not added then the compilation is failing.
Yosys is compiled with this option: 'make install ENABLE_LIBYOSYS=1 LINK_ABC=1'